### PR TITLE
Refactor path handling to pathlib

### DIFF
--- a/getRecipes.py
+++ b/getRecipes.py
@@ -6,6 +6,7 @@ import zipfile
 import xml.etree.cElementTree
 import pandas as pd
 import numpy as np
+from pathlib import Path
 
 
 def p_press(MO, bub_temp):
@@ -24,15 +25,13 @@ def p_press(MO, bub_temp):
     press = 10.0**(gas_con.loc["B",MO]-gas_con.loc["A",MO]/(273.15+float(bub_temp)+gas_con.loc["C",MO]))
     return float(press)
 
-def runDoc(runs_location="./",start_row = 670):
+def runDoc(runs_location="./", start_row=670):
     """
 
     :param runs_location:
     :return: raw dataframe of runs.docx
     """
-    if runs_location[-1]!="/":
-        runs_location = runs_location+"/"
-
+    runs_path = Path(runs_location)
 
     WORD_NAMESPACE = '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}'
     PARA = WORD_NAMESPACE + 'p'
@@ -41,7 +40,7 @@ def runDoc(runs_location="./",start_row = 670):
     ROW = WORD_NAMESPACE + 'tr'
     CELL = WORD_NAMESPACE + 'tc'
 
-    with zipfile.ZipFile(runs_location + "Runs.docx") as docx:
+    with zipfile.ZipFile(runs_path / "Runs.docx") as docx:
         tree = xml.etree.cElementTree.XML(docx.read('word/document.xml'))
 
     i = 1

--- a/hall.py
+++ b/hall.py
@@ -4,6 +4,7 @@ HALL_data = []
 import os
 import re
 import pandas as pd
+from pathlib import Path
 
 ###Get results from a single file
 def getFile(result_filename, folder="./", thickness_file="AZO_hall_thicknesses_20170314.txt"):
@@ -68,22 +69,21 @@ def getFile(result_filename, folder="./", thickness_file="AZO_hall_thicknesses_2
 
 
 ##get results from all files in folder
-def getFolder(folder,thickness_file="AZO_hall_thicknesses_20170314.txt"):
+def getFolder(folder, thickness_file="AZO_hall_thicknesses_20170314.txt"):
     hall_data = []
-    if not folder.endswith("/"):
-        folder = folder+"/"
+    folder = Path(folder)
 
-    files_in_folder = [x for x in os.listdir(folder) if (x.endswith(".txt") and x !=thickness_file and x !="folderIndex.txt")]
+    files_in_folder = [x for x in os.listdir(folder) if (x.endswith(".txt") and x != thickness_file and x != "folderIndex.txt")]
 
     for items in files_in_folder:
         run_no_in_name = re.search("(\d\d\d)([RrCcMmAa])", items)
         if not run_no_in_name:
-            print(items,"run_no missing")
+            print(items, "run_no missing")
             continue
 
         file = items.strip()
 
-        results = getFile(folder+file, folder=folder,thickness_file=thickness_file)
+        results = getFile(folder / file, folder=str(folder), thickness_file=thickness_file)
 
         if results == "nothing":
             continue

--- a/sims.py
+++ b/sims.py
@@ -7,6 +7,7 @@ import pandas as pd
 import os
 import re
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 def getFile(filename):
@@ -104,15 +105,14 @@ def getFolder(folder, figures=False):
         return SIMS_data a dictionary with filename, run_no, sub, and data as a df
 
     """
-    if not folder.endswith("/"):
-        folder = folder + "/"
+    folder = Path(folder)
 
     sample_index = "SIMS_sample_index.txt"
 
     sims_data = []
 
 ### Record data from each file so that the calibration files can be used in next loop.
-    with open(folder + sample_index, "r") as f:
+    with open(folder / sample_index, "r") as f:
         for lines in f:
 
             if lines.startswith("#") or not lines.strip():
@@ -130,7 +130,7 @@ def getFolder(folder, figures=False):
                 sub = None
                 filename = lines.split()[0]
 
-            file_data = sims_class(folder + filename)
+            file_data = sims_class(folder / filename)
 
             sims_data.append({"filename": filename, "data": file_data, "run_no": run_no, "sub": sub})
 
@@ -165,10 +165,10 @@ def getFolder(folder, figures=False):
         #### Save figure for visual check of SIMS data fit
         if figures == True:
 
-            figure_folder = folder + "SIMS_fits/"
+            figure_folder = folder / "SIMS_fits"
 
-            if not os.path.exists(figure_folder):
-                os.makedirs(figure_folder)
+            if not figure_folder.exists():
+                figure_folder.mkdir(parents=True, exist_ok=True)
             save_name = "SIMS_%s%s.png" % (s["run_no"], s["sub"])
 
             f, ax = plt.subplots(1, 1)
@@ -195,7 +195,7 @@ def getFolder(folder, figures=False):
             window = (data.iloc[sims_object.window[0]]["Depth"], data.iloc[sims_object.window[1]]["Depth"])
             ax.axvline(window[0])
             ax.axvline(window[1])
-            f.savefig(figure_folder + save_name)
+            f.savefig(figure_folder / save_name)
             plt.close("all")
     return sims_data
 


### PR DESCRIPTION
## Summary
- Use `pathlib.Path` in `getRecipes.runDoc` for building `Runs.docx` paths
- Switch `hall.getFolder` to `Path` and path joins for hall data parsing
- Refactor `sims.getFolder` to join paths with `Path` and handle figure directories

## Testing
- `pytest`
- `python -m py_compile getRecipes.py hall.py sims.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7fdd8c038832fbcf051c9a8ac46f7