### PR TITLE
Refactor sample handling with dataclass

### DIFF
--- a/hall.py
+++ b/hall.py
@@ -125,10 +125,10 @@ def getFolder(folder, thickness_file="AZO_hall_thicknesses_20170314.txt"):
 def to_list(samples_data, hall_data):
     for dataset in samples_data:
         for h_sample in hall_data:
-            if dataset["run_no"] == h_sample["run_no"] and dataset["sub"] == h_sample["sub"]:
-                dataset.update({"hall_n": h_sample["hall_n"],
-                                "hall_p": h_sample["hall_p"],
-                                "hall_mob": h_sample["hall_mob"],
-                                "hall_thick": h_sample["thickness"]})
+            if dataset.run_no == h_sample["run_no"] and dataset.sub == h_sample["sub"]:
+                dataset.hall_n = h_sample["hall_n"]
+                dataset.hall_p = h_sample["hall_p"]
+                dataset.hall_mob = h_sample["hall_mob"]
+                dataset.hall_thick = h_sample["thickness"]
 
-                print("ok", dataset["run_no"], dataset["sub"])
+                print("ok", dataset.run_no, dataset.sub)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["Sample"]
+from .sample import Sample

--- a/models/sample.py
+++ b/models/sample.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Sample:
+    run_no: str
+    sub: str
+    hall_n: Optional[float] = None
+    hall_p: Optional[float] = None
+    hall_mob: Optional[float] = None
+    hall_thick: Optional[float] = None
+    t_bandgap: Optional[float] = None
+    Al_content: Optional[float] = None
+    Al_error: Optional[float] = None
+    Zn_content: Optional[float] = None
+    Zn_error: Optional[float] = None
+    SIMS_T: Optional[float] = None
+    DEZn_molar: Optional[float] = None
+    TEGa_molar: Optional[float] = None
+    TMAl_molar: Optional[float] = None
+    tBuOH_molar: Optional[float] = None
+    MO_total: Optional[float] = None
+    vi_ii: Optional[float] = None
+    vi_mo: Optional[float] = None
+    ii: Optional[float] = None
+    iii: Optional[float] = None
+    vi: Optional[float] = None
+    TMAl_flow: Optional[float] = None
+    tBuOH_flow: Optional[float] = None
+    MO_carrier: Optional[float] = None
+    DEZn_flow: Optional[float] = None
+    TEGa_flow: Optional[float] = None
+    Gas_carrier: Optional[float] = None
+    rocking13: Optional[float] = None
+    rocking23: Optional[float] = None

--- a/sims.py
+++ b/sims.py
@@ -202,10 +202,9 @@ def getFolder(folder, figures=False):
 def to_list(samples_data, sims_data):
     for dataset in samples_data:
         for sim in sims_data:
-            if str(dataset["run_no"]) == str(sim["run_no"]) and str(dataset["sub"]) == str(sim["sub"]):
-                dataset.update(
-                    {"Al_content": sim["Al_content"],
-                     "Al_error": sim["Al_error"],
-                     "Zn_content": sim["Zn_content"],
-                     "Zn_error": sim["Zn_error"],
-                     "SIMS_T": sim["SIMS_T"]})
+            if str(dataset.run_no) == str(sim["run_no"]) and str(dataset.sub) == str(sim["sub"]):
+                dataset.Al_content = sim["Al_content"]
+                dataset.Al_error = sim["Al_error"]
+                dataset.Zn_content = sim["Zn_content"]
+                dataset.Zn_error = sim["Zn_error"]
+                dataset.SIMS_T = sim["SIMS_T"]

--- a/spectro.py
+++ b/spectro.py
@@ -342,6 +342,5 @@ def taucfolder(t_folder):
 def to_list(samples_data, uv_data):
     for dataset in samples_data:
         for u_sample in uv_data:
-            if dataset["run_no"] == u_sample["run_no"] and dataset["sub"] == u_sample["sub"]:
-                dataset.update(
-                    {"t_bandgap": u_sample["t_bandgap"]})
+            if dataset.run_no == u_sample["run_no"] and dataset.sub == u_sample["sub"]:
+                dataset.t_bandgap = u_sample["t_bandgap"]

--- a/xrd.py
+++ b/xrd.py
@@ -715,7 +715,7 @@ def rock_to_list(samples_data,rock_list):
     """
     for r_dat in rock_list:
         for sam_dat in samples_data:
-            if r_dat["run_no"] == sam_dat["run_no"] and r_dat["sub"] == sam_dat["sub"]:
+            if r_dat["run_no"] == sam_dat.run_no and r_dat["sub"] == sam_dat.sub:
                     d_range = r_dat["range"]
                     if d_range[0] in ["12","13"]:
                         rkey = "rocking13"
@@ -724,8 +724,8 @@ def rock_to_list(samples_data,rock_list):
                         rkey = "rocking23"
                         other_key = "rocking13"
 
-                    sam_dat.update({rkey:r_dat["fwhm"],
-                                    other_key: np.nan})
+                    setattr(sam_dat, rkey, r_dat["fwhm"])
+                    setattr(sam_dat, other_key, np.nan)
                     continue
 
 def fit_xrd_folder(xrd_folder, XRD_data, noise = 1e-2):


### PR DESCRIPTION
## Summary
- add `Sample` dataclass to centralize sample attributes
- return `Sample` objects from `make_samples_data` and update flow calculations
- adjust hall, spectro, sims, and xrd merging to populate `Sample` attributes

## Testing
- `python -m py_compile models/sample.py getRecipes.py hall.py spectro.py sims.py xrd.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c802e2b69c832f9f1a96c26e31ce74